### PR TITLE
Fix executable files installation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "url": "git://github.com/ckknight/gorillascript"
   },
   "main": "index",
-  "bin": "./bin/gorilla",
+  "bin": {
+    "gorilla" : "./bin/gorilla",
+    "gork": "./bin/gork"
+  },
   "readmeFilename": "README"
 }


### PR DESCRIPTION
When I install gorillascript from npm, there is only one gorillascript in my $PATH.
I followed `npm help json` instruction fix the "bin" field.

BTW: You may add "altjs" to the "keywords" field.
