### PR TITLE
Add .gitignore, add -b option.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.js.bak
+node_modules

--- a/lib/command.js
+++ b/lib/command.js
@@ -178,6 +178,7 @@
     cli.setUsage("gorilla [OPTIONS] path/to/script.gs");
     parseOptions = {
       ast: ["a", "Display JavaScript AST nodes instead of compilation"],
+      bare: ["b", "Compile without safety top-level closure wrapper"],
       compile: ["c", "Compile to JavaScript and save as .js files"],
       output: ["o", "Set the file/directory for compiled JavaScript", "path"],
       interactive: ["i", "Run interactively with the REPL"],
@@ -211,6 +212,9 @@
       }
       if (options.minify) {
         opts.minify = true;
+      }
+      if (options.bare) {
+        opts.bare = true;
       }
       if (options["no-prelude"]) {
         _f = function (next) {

--- a/src/command.gs
+++ b/src/command.gs
@@ -17,6 +17,7 @@ cli.set-usage "gorilla [OPTIONS] path/to/script.gs"
 
 let parse-options =
   ast:          ["a", "Display JavaScript AST nodes instead of compilation"]
+  bare:         ["b", "Compile without safety top-level closure wrapper"]
   compile:      ["c", "Compile to JavaScript and save as .js files"]
   output:       ["o", "Set the file/directory for compiled JavaScript", "path"]
   interactive:  ["i", "Run interactively with the REPL"]
@@ -48,6 +49,8 @@ if options.uglify
   opts.uglify := true
 if options.minify
   opts.minify := true
+if options.bare
+  opts.bare := true
 
 asyncif next, options["no-prelude"]
   opts.no-prelude := true


### PR DESCRIPTION
I'm following vim-coffee-script making gorilla-script vim plugins, it has a vim partical compiling function, that you select some lines then show the compiled result in a new window. Using `bare: true` is easier to read compiled code in vim scratch window.
