### PR TITLE
Add sourcemap generator into compile procedure.

### DIFF
--- a/bin/gorilla
+++ b/bin/gorilla
@@ -8,4 +8,4 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-node --harmony_collections "$DIR/../lib/command" "$@"
+node --harmony "$DIR/../lib/command" "$@"

--- a/extras/gorillascript.js
+++ b/extras/gorillascript.js
@@ -446,7 +446,7 @@
           function Cache() {
             var _this;
             _this = this instanceof Cache ? this : __create(_Cache_prototype);
-            _this.weakmap = WeakMap();
+            _this.weakmap = new WeakMap();
             return _this;
           }
           _Cache_prototype = Cache.prototype;
@@ -26584,7 +26584,7 @@
             _this.scope = scope;
             _this.hasGeneratorNode = hasGeneratorNode;
             _this.currentCatch = [];
-            _this.redirects = Map();
+            _this.redirects = new Map();
             _this.start = GeneratorState(_this);
             _this.stop = GeneratorState(_this).add(function () {
               return ast.Return(pos, ast.Obj(pos, [
@@ -26634,7 +26634,7 @@
           _GeneratorBuilder_prototype._calculateCaseIds = function () {
             var _arr, _i, _len, caseIds, id, state;
             id = -1;
-            caseIds = this.caseIds = Map();
+            caseIds = this.caseIds = new Map();
             for (_arr = __toArray(this.statesOrder), _i = 0, _len = _arr.length; _i < _len; ++_i) {
               state = _arr[_i];
               if (!this.redirects.has(state)) {

--- a/lib/gorilla.js
+++ b/lib/gorilla.js
@@ -1,10 +1,11 @@
 (function (GLOBAL) {
   "use strict";
-  var __defer, __everyPromise, __generatorToPromise, __import, __isArray, __lte,
-      __num, __owns, __promise, __promiseLoop, __slice, __strnum, __toArray,
-      __toPromise, __typeof, _ref, ast, fetchAndParsePreludeMacros, fs, init,
-      isAcceptableIdent, os, parser, path, real__filename, setImmediate,
-      SourceMap, writeFileWithMkdirp, writeFileWithMkdirpSync;
+  var __defer, __everyPromise, __generatorToPromise, __import, __is, __isArray,
+      __lte, __num, __owns, __promise, __promiseLoop, __slice, __strnum,
+      __toArray, __toPromise, __typeof, _ref, ast, fetchAndParsePreludeMacros,
+      fs, init, isAcceptableIdent, os, parser, path, real__filename,
+      setImmediate, SourceMap, SourceMapConsumer, writeFileWithMkdirp,
+      writeFileWithMkdirpSync;
   __defer = (function () {
     function __defer() {
       var deferred, isError, value;
@@ -212,6 +213,14 @@
     }
     return dest;
   };
+  __is = typeof Object.is === "function" ? Object.is
+    : function (x, y) {
+      if (x === y) {
+        return x !== 0 || 1 / x === 1 / y;
+      } else {
+        return x !== x && y !== y;
+      }
+    };
   __isArray = typeof Array.isArray === "function" ? Array.isArray
     : (function (_toString) {
       return function (x) {
@@ -414,6 +423,7 @@
   fs = require("fs");
   path = require("path");
   SourceMap = require("./source-map");
+  SourceMapConsumer = require("source-map").SourceMapConsumer;
   _ref = require("./utils");
   writeFileWithMkdirp = _ref.writeFileWithMkdirp;
   writeFileWithMkdirpSync = _ref.writeFileWithMkdirpSync;
@@ -1045,6 +1055,9 @@
           }
           sync = options.sync;
           startTime = new Date().getTime();
+          if (options.filename) {
+            options.sourceMap = SourceMap(options.filename, null, "");
+          }
           _state = sync ? 1 : 2;
           break;
         case 1:
@@ -1524,6 +1537,88 @@
     }
     return exports["eval"].sync(source, (_ref = __import({}, options), _ref.sync = true, _ref));
   };
+  function patchStackTrace(options) {
+    if (options.stackTracePatched) {
+      return;
+    }
+    options.stackTracePatched = true;
+    return Error.prepareStackTrace = function (err, stack) {
+      var _arr, _arr2, _i, _len, frame, frames;
+      function getSourceMapping(pos) {
+        var mapping;
+        mapping = new SourceMapConsumer(options.sourceMap.toString());
+        return mapping.originalPositionFor(pos);
+      }
+      function formatSourcePosition(frame) {
+        var asLine, column, fileLocation, fileName, functionName, isConstructor,
+            isMethodCall, line, methodName, source, tp, typeName;
+        fileLocation = "";
+        if (frame.isNative()) {
+          return fileLocation = "native";
+        } else {
+          if (frame.isEval()) {
+            fileName = frame.getScriptNameOrSourceURL();
+            if (!fileName) {
+              fileLocation = __strnum(frame.getEvalOrigin()) + ", ";
+            }
+          } else {
+            fileName = frame.getFileName();
+          }
+          if (!fileName) {
+            fileName = "<anonymous>";
+          }
+          line = frame.getLineNumber();
+          column = frame.getColumnNumber();
+          source = getSourceMapping({ line: line, column: column });
+          if (__num(fileName.indexOf(".js")) < 1) {
+            if (source.line != null) {
+              fileLocation = __strnum(fileName) + ":" + __strnum(source.line) + ":" + __strnum(source.column) + ", <js>:" + __strnum(line) + ":" + __strnum(column);
+            } else {
+              fileLocation = __strnum(fileName) + " <js>:" + __strnum(line) + ":" + __strnum(column);
+            }
+          } else {
+            fileLocation = __strnum(fileName) + ":" + __strnum(line) + ":" + __strnum(column);
+          }
+          functionName = frame.getFunctionName();
+          isConstructor = frame.isConstructor();
+          isMethodCall = !frame.isToplevel() && !isConstructor;
+          if (isMethodCall) {
+            methodName = frame.getMethodName();
+            typeName = frame.getTypeName();
+            if (functionName) {
+              tp = "";
+              asLine = "";
+              if (typeName && functionName.indexOf(typeName)) {
+                tp = __strnum(typeName) + ".";
+              }
+              if (methodName && !__is(functionName.indexOf("." + __strnum(methodName)), __num(functionName.length) - __num(methodName.length) - 1)) {
+                asLine = " [as " + __strnum(methodName) + "]";
+              }
+              return tp + __strnum(functionName) + asLine + " (" + fileLocation + ")";
+            } else {
+              return __strnum(typeName) + "." + __strnum(methodName || "<anonymous>") + " (" + fileLocation + ")";
+            }
+          } else if (isConstructor) {
+            return "new " + __strnum(functionName || "<anonymous>") + " (" + fileLocation + ")";
+          } else if (functionName) {
+            return __strnum(functionName) + " (" + fileLocation + ")";
+          } else {
+            return fileLocation;
+          }
+        }
+      }
+      _arr = [];
+      for (_arr2 = __toArray(stack), _i = 0, _len = _arr2.length; _i < _len; ++_i) {
+        frame = _arr2[_i];
+        if (__is(frame.getFunction(), exports.run)) {
+          break;
+        }
+        _arr.push("  at " + __strnum(formatSourcePosition(frame)));
+      }
+      frames = _arr;
+      return err.toString() + "\n" + frames.join("\n") + "\n";
+    };
+  }
   exports.run = __promise(function (source, options) {
     var _e, _send, _state, _step, _throw, compiled, mainModule, Module, sync;
     _state = 0;
@@ -1537,6 +1632,7 @@
           if (options == null) {
             options = {};
           }
+          options.stackTracePatched = false;
           sync = options.sync;
           _state = typeof process === "undefined" ? 1 : 5;
           break;
@@ -1587,6 +1683,7 @@
           compiled = _received;
           ++_state;
         case 10:
+          patchStackTrace(options);
           _state = 12;
           return {
             done: true,

--- a/lib/jstranslator.js
+++ b/lib/jstranslator.js
@@ -1076,7 +1076,7 @@
       _this.scope = scope;
       _this.hasGeneratorNode = hasGeneratorNode;
       _this.currentCatch = [];
-      _this.redirects = Map();
+      _this.redirects = new Map();
       _this.start = GeneratorState(_this);
       _this.stop = GeneratorState(_this).add(function () {
         return ast.Return(pos, ast.Obj(pos, [
@@ -1126,7 +1126,7 @@
     _GeneratorBuilder_prototype._calculateCaseIds = function () {
       var _arr, _i, _len, caseIds, id, state;
       id = -1;
-      caseIds = this.caseIds = Map();
+      caseIds = this.caseIds = new Map();
       for (_arr = __toArray(this.statesOrder), _i = 0, _len = _arr.length; _i < _len; ++_i) {
         state = _arr[_i];
         if (!this.redirects.has(state)) {

--- a/lib/source-map.js
+++ b/lib/source-map.js
@@ -15,6 +15,9 @@
       var _this;
       _this = this instanceof SourceMap ? this : __create(_SourceMap_prototype);
       _this.sourceMapFile = sourceMapFile;
+      if (generatedFile == null) {
+        generatedFile = "temp";
+      }
       _this.generatedFile = generatedFile;
       _this.generator = new (sourceMap.SourceMapGenerator)({
         file: path.relative(path.dirname(sourceMapFile), generatedFile),

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -427,7 +427,7 @@
     function Cache() {
       var _this;
       _this = this instanceof Cache ? this : __create(_Cache_prototype);
-      _this.weakmap = WeakMap();
+      _this.weakmap = new WeakMap();
       return _this;
     }
     _Cache_prototype = Cache.prototype;

--- a/src/jsprelude.gs
+++ b/src/jsprelude.gs
@@ -1851,7 +1851,7 @@ macro for
       $current
 
 macro helper __generic-func = #(num-args as Number, make as ->)
-  let cache = WeakMap()
+  let cache = new WeakMap()
   let any = {}
   let generic = #
     for reduce i in num-args - 1 to 0 by -1, current = cache
@@ -1861,7 +1861,7 @@ macro helper __generic-func = #(num-args as Number, make as ->)
         item := if i == 0
           make@ this, ...arguments
         else
-          WeakMap()
+          new WeakMap()
         current.set type, item
       item
   let result = generic()
@@ -3726,7 +3726,7 @@ macro operator unary set! with type: \object, label: \construct-set
   node := @macro-expand-1 node
   if node.is-internal-call \array
     if node.args.length == 0
-      ASTE Set()
+      ASTE new Set()
     else
       let parts = []
       let tmp = @tmp \x
@@ -3737,13 +3737,13 @@ macro operator unary set! with type: \object, label: \construct-set
         else
           parts.push AST(el) $set.add $el
       AST
-        let $set = Set()
+        let $set = new Set()
         $parts
         $set
   else
     let item = @tmp \x
     AST
-      let $set as Set = Set()
+      let $set as Set = new Set()
       for $item in $node
         $set.add $item
       $set
@@ -3755,7 +3755,7 @@ macro operator unary map! with type: \object, label: \construct-map
   if node.is-internal-call \object
     let pairs = node.args
     if pairs.length == 0
-      ASTE Map()
+      ASTE new Map()
     else
       let parts = []
       for pair in pairs[1 to -1]
@@ -3763,14 +3763,14 @@ macro operator unary map! with type: \object, label: \construct-map
           @error "Cannot use map! on an object with custom properties", pair
         parts.push AST(pair) $map.set $(pair.args[0]), $(pair.args[1])
       AST
-        let $map as Map = Map()
+        let $map as Map = new Map()
         $parts
         $map
   else
     let key = @tmp \k
     let value = @tmp \v
     AST
-      let $map as Map = Map()
+      let $map as Map = new Map()
       for $key, $value of $node
         $map.set $key, $value
       $map

--- a/src/jstranslator.gs
+++ b/src/jstranslator.gs
@@ -379,7 +379,7 @@ class GeneratorState
 class GeneratorBuilder
   def constructor(@pos as {}, @scope as Scope, @has-generator-node as ->)
     @current-catch := []
-    @redirects := Map()
+    @redirects := new Map()
     @start := GeneratorState(this)
     @stop := GeneratorState(this).add #-> ast.Return pos, ast.Obj pos, [
       ast.Obj.Pair pos, \done, ast.Const pos, true
@@ -418,7 +418,7 @@ class GeneratorBuilder
   
   def _calculate-case-ids()!
     let mutable id = -1
-    let case-ids = @case-ids := Map()
+    let case-ids = @case-ids := new Map()
     for state in @states-order
       if not @redirects.has state
         case-ids.set state, (id += 1)

--- a/src/parser.gs
+++ b/src/parser.gs
@@ -100,7 +100,7 @@ class Box
     if index not %% 1 or index < 0
       throw RangeError "Expected index to be a non-negative integer, got $index"
 
-let unused-caches = if DEBUG then Map()
+let unused-caches = if DEBUG then new Map()
 
 let cache = do
   let mutable id = -1

--- a/src/source-map.gs
+++ b/src/source-map.gs
@@ -4,7 +4,7 @@ require! source-map: "source-map"
 require! path
 
 module.exports := class SourceMap
-  def constructor(@source-map-file, @generated-file, source-root)
+  def constructor(@source-map-file, @generated-file = 'temp', source-root)
     @generator := new source-map.SourceMapGenerator {
       file: path.relative path.dirname(source-map-file), generated-file
       source-root

--- a/src/utils.gs
+++ b/src/utils.gs
@@ -21,7 +21,7 @@ let pad-right(text, len, padding)
 
 class Cache<TKey, TValue>
   def constructor()
-    @weakmap := WeakMap()
+    @weakmap := new WeakMap()
   
   def get(key as TKey) -> @weakmap.get(key)
   


### PR DESCRIPTION
Now you can have original source position in stack trace.

``` gorillascript
let x()
  throw new Error("hello")

x()
```

``` log
Error: hello
  at x (/home/unco/snips/gerror/error.gs:2:8, <js>:4:11)
  at Object.<anonymous> (/home/unco/snips/gerror/error.gs:4:1, <js>:6:3)
  at Object.<anonymous> (/home/unco/snips/gerror/error.gs <js>:7:3)
  at Module._compile (module.js:456:26)
  at _step (/home/unco/repos/new/gorillascript/lib/gorilla.js:1690:31)
  at Object._send [as send] (/home/unco/repos/new/gorillascript/lib/gorilla.js:1710:16)
  at continuer (/home/unco/repos/new/gorillascript/lib/gorilla.js:189:31)
  at callback (/home/unco/repos/new/gorillascript/lib/gorilla.js:200:14)
  at Array.step [as 0] (/home/unco/repos/new/gorillascript/lib/gorilla.js:53:28)
  at Object._onImmediate (/home/unco/repos/new/gorillascript/lib/gorilla.js:26:25)
```

BTW, the sourcemap generated by gorillascript is not correct in the first trace frame.
