### PR TITLE
Fix for constants in do statements

### DIFF
--- a/src/jsprelude.gs
+++ b/src/jsprelude.gs
@@ -1150,7 +1150,7 @@ macro do
           f i + 1
       f 0
       @call(
-        @func(params, @internal-call(\auto-return, body), true)
+        @func(params, @internal-call(\auto-return, @macro-expand-all(body)), true)
         values)
     else
       ASTE (#@ -> $body)()


### PR DESCRIPTION
In the instance of having a "do" statement with a constant defined, and a macro inside of the do statement that tries to get the value of the constant, the constant wouldn't be defined. I simply added macro-expand-all to evaluate the constant. This may or may not be the right fix for the problem.

The issue appears to only occur when the do statement has variable assignments. See below for an example:

```
macro getConst()
    let value = @getConstValue \VALUE
    AST $value

// Works
do
    const VALUE = \asdf
    console.log getConst()

// Does not work
do A = B
    const VALUE = \asdf
    console.log getConst()
```
